### PR TITLE
Add stock portfolio page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,9 @@
 <header>
     <nav>
-        <div class="logo">Portfolio</div>
+        <div class="logo"><a href="/" class="logo-link">Portfolio</a></div>
+        <div class="nav-links">
+            <a href="/stockportfolio.html">Stock Portfolio</a>
+        </div>
         <div class="mode-switch">
             <span class="mode-label" id="modeLabel">Portfolio</span>
             <div class="switch" id="modeSwitch"></div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -94,6 +94,22 @@ nav {
     margin: 0 auto;
 }
 
+.nav-links {
+    display: flex;
+    gap: 1rem;
+}
+
+.nav-links a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+.nav-links a:hover {
+    color: var(--accent);
+}
+
 .logo {
     font-size: 1.5rem;
     font-weight: 700;
@@ -332,6 +348,29 @@ main {
     border-color: var(--accent);
     color: var(--accent);
     transform: translateY(-2px);
+}
+
+/* Stock portfolio table */
+.stock-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 2rem;
+}
+
+.stock-table th,
+.stock-table td {
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border);
+}
+
+.stock-table th {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    text-align: left;
+}
+
+.stock-table tbody tr:nth-child(odd) {
+    background: var(--bg-tertiary);
 }
 
 /* Footer */

--- a/stockportfolio.html
+++ b/stockportfolio.html
@@ -1,0 +1,38 @@
+---
+layout: default
+title: Stock Portfolio
+---
+
+<section class="portfolio-section">
+    <h2 class="section-title">Stock Portfolio</h2>
+    <table class="stock-table">
+        <thead>
+            <tr>
+                <th>Symbol</th>
+                <th>Shares</th>
+                <th>Price</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>AAPL</td>
+                <td>10</td>
+                <td>$150.00</td>
+                <td>$1,500.00</td>
+            </tr>
+            <tr>
+                <td>GOOGL</td>
+                <td>5</td>
+                <td>$2,800.00</td>
+                <td>$14,000.00</td>
+            </tr>
+            <tr>
+                <td>TSLA</td>
+                <td>8</td>
+                <td>$700.00</td>
+                <td>$5,600.00</td>
+            </tr>
+        </tbody>
+    </table>
+</section>


### PR DESCRIPTION
## Summary
- add a stock portfolio page with sample data
- link new page from the header navigation
- style navigation and table in CSS

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685eb00b18cc832cbf1dc86e127ef310